### PR TITLE
chore: add webhook curl request to deployment action

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -4,15 +4,25 @@ name: Fly Deploy
 on:
   push:
     tags:
-      - 'fts-demo-v[0-9]+.[0-9]+.[0-9]+'
+      - "fts-demo-v[0-9]+.[0-9]+.[0-9]+"
 jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
-    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  build-docs:
+    name: Rebuild docs website
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: POST via curl
+        run: |
+          curl -X POST "$WEBHOOK_URL"
+        env:
+          WEBHOOK_URL: ${{ vars.CLOUDFLARE_PAGES_WEBHOOK }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -23,6 +23,6 @@ jobs:
     steps:
       - name: POST via curl
         run: |
-          curl -X POST "$WEBHOOK_URL"
+          curl -X POST --fail "$WEBHOOK_URL"
         env:
-          WEBHOOK_URL: ${{ vars.CLOUDFLARE_PAGES_WEBHOOK }}
+          WEBHOOK_URL: ${{ secrets.CLOUDFLARE_PAGES_WEBHOOK }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,3 +1,4 @@
+name: PR Checks
 on:
   pull_request:
     branches: [ main ]

--- a/fly.toml
+++ b/fly.toml
@@ -8,6 +8,9 @@ primary_region = 'bos'
 
 [build]
 
+[deploy]
+wait_timeout = "1m"
+
 [http_service]
   internal_port = 8080
   force_https = true
@@ -15,6 +18,12 @@ primary_region = 'bos'
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']
+  
+  [[http_service.checks]]
+    grace_period = "5s"
+    interval = "30s"
+    timeout = "5s"
+    path = "/healthsss"
 
 [env]
   API_PORT = "8080"

--- a/fts-server/src/lib.rs
+++ b/fts-server/src/lib.rs
@@ -10,6 +10,7 @@ use fts_core::{
     ports::{AuctionRepository, MarketRepository},
 };
 
+use axum::Json;
 use axum::Router;
 use axum::http::header;
 use axum::response::sse::Event;
@@ -75,6 +76,19 @@ pub struct Update<T> {
     /// Outcome data from the auction
     #[serde(flatten)]
     pub outcome: T,
+}
+
+/// Response for the health check endpoint
+#[derive(Serialize)]
+struct HealthResponse {
+    status: String,
+}
+
+/// Simple health check endpoint
+async fn health_check() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok".to_string(),
+    })
 }
 
 /// Creates the application state and solver background task.
@@ -214,6 +228,7 @@ pub fn router<T: MarketRepository>(state: AppState<T>) -> Router {
 
     // Wire it together
     let app = Router::new()
+        .route("/health", axum::routing::get(health_check))
         .nest("/v0/auths", routes::auths::router())
         .nest("/v0/costs", routes::costs::router())
         // Bidder-specific routes for their submission


### PR DESCRIPTION
I reviewed the implementation of the "blessed" webhook action: https://github.com/marketplace/actions/workflow-webhook-action

It's fine, but overkill when all we need a POST request with no data (no supply chain attacks for us!). I verified that the curl request, when executed in my terminal, successfully triggers a build and deployment on Cloudflare. I have not tested whether variable properly propagates into the command specified in the action.

I also took care to specify the job dependency of the build-docs action on the success of the deploy action. This is operating by assumption, but I assume `flyctl deploy` returns an error code if the deployment fails, and a success code once the docker image is running? If that is not the case something else will need to be done.

There is an open question: how do we verify that the rebuild waits until the app is launched? Should we amend the docs website to provide an md5 checksum of the schema file, then compare when the dust settles?