### PR TITLE
fix: fixed package error for fts-solver & endpoint

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -23,7 +23,7 @@ wait_timeout = "1m"
     grace_period = "5s"
     interval = "30s"
     timeout = "5s"
-    path = "/healthsss"
+    path = "/health"
 
 [env]
   API_PORT = "8080"

--- a/fts-solver/Cargo.toml
+++ b/fts-solver/Cargo.toml
@@ -14,7 +14,7 @@ clarabel = { version = "0.10", optional = true }
 osqp = { version = "1.0", optional = true }
 
 fxhash = { workspace = true }
-indexmap = { workspace = true, features = ["std"] }
+indexmap = { workspace = true, features = ["std", "serde"] }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
The `serde` feature also needed to be enabled in `fts-solver` crate - this passed under the radar because we build from the workspace, and there the feature is enabled because it is specified in `fts-core`.