### PR TITLE
fix: simplify github deploy action

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -44,14 +44,5 @@ jobs:
         run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  build-docs:
-    name: Rebuild docs website
-    runs-on: ubuntu-latest
-    needs: deploy
-    steps:
-      - name: POST via curl
-        run: |
-          curl -X POST --fail "$WEBHOOK_URL"
-        env:
-          WEBHOOK_URL: ${{ secrets.CLOUDFLARE_PAGES_WEBHOOK }}
+      - name: Rebuild docs website
+        run: curl -X POST --fail "${{ secrets.CLOUDFLARE_PAGES_WEBHOOK }}"


### PR DESCRIPTION
Context: The last job was still skipped, even though the fly.io deployment succeeded. Most likely due to the DAG, since the last job depended on deploy, which depended on a skipped job. Instead of including yet another horrible if statement for the last job, I decided to just add it as a step to the deploy job.