### PR TITLE
62 feat add   schedule  args to ftdemo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,6 +796,7 @@ dependencies = [
  "fts-server",
  "fts-sqlite",
  "humantime",
+ "time",
  "tokio",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "humantime",
  "time",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 

--- a/ftdemo/Cargo.toml
+++ b/ftdemo/Cargo.toml
@@ -17,10 +17,11 @@ fts-sqlite = { path = "../fts-sqlite", version = "0.1.5" }
 clap = { workspace = true, features = ["derive", "env"] }
 dotenvy = { version = "0.15" }
 humantime = { workspace = true }
-time = { workspace = true, features = ["parsing"] }
+time = { workspace = true, features = ["formatting", "parsing"] }
 
 # For running the server
 tokio = { workspace = true, features = ["full"] }
+tracing = { workspace = true }
 
 # For reporting the traces
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/ftdemo/Cargo.toml
+++ b/ftdemo/Cargo.toml
@@ -17,6 +17,7 @@ fts-sqlite = { path = "../fts-sqlite", version = "0.1.5" }
 clap = { workspace = true, features = ["derive", "env"] }
 dotenvy = { version = "0.15" }
 humantime = { workspace = true }
+time = { workspace = true, features = ["parsing"] }
 
 # For running the server
 tokio = { workspace = true, features = ["full"] }

--- a/ftdemo/src/main.rs
+++ b/ftdemo/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Args, Parser};
 use fts_core::models::Config;
 use fts_sqlite::db::{self, Database};
 use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
@@ -19,7 +19,7 @@ async fn main() -> Result<(), db::Error> {
 
     // We will need to collect whatever data is necessary to configure the API
     // server. The `Args` struct, defined after this function, does this job for us.
-    let args = Args::import();
+    let args = Cli::import();
 
     match args {
         Ok(args) => {
@@ -46,6 +46,9 @@ async fn main() -> Result<(), db::Error> {
             // Finally, we provide this data to the API module, which creates an HTTP
             // server on the specified port.
             fts_server::start(args.api_port, args.api_secret, database).await;
+
+            // TODO: craft an f(from, thru) function that triggers the solve.
+            // args.schedule.schedule(f)
         }
         Err(e) => {
             let _ = e.print();
@@ -57,7 +60,7 @@ async fn main() -> Result<(), db::Error> {
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
-pub struct Args {
+pub struct Cli {
     /// The port to listen on
     #[arg(long, default_value_t = 8080, env = "API_PORT")]
     pub api_port: u16,
@@ -78,12 +81,72 @@ pub struct Args {
     /// The time unit of rate data
     #[arg(long, env = "TRADE_RATE")]
     pub trade_rate: humantime::Duration,
+
+    /// The args related to scheduling batch execution
+    #[command(flatten)]
+    pub schedule: Scheduler,
 }
 
-impl Args {
+impl Cli {
     pub fn import() -> Result<Self, clap::Error> {
         // Attempt to load a .env file, but don't sweat it if one is not found.
         let _ = dotenvy::dotenv();
         Self::try_parse()
     }
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct Scheduler {
+    /// An RFC3339 timestamp to start the auction schedule from (if omitted or empty, defaults to now)
+    #[arg(long, requires = "schedule", env = "SCHEDULE_FROM", value_parser = parse_timestamp)]
+    pub schedule_from: Option<time::OffsetDateTime>,
+    /// How often to execute an auction
+    #[arg(long, group = "schedule", env = "SCHEDULE_EVERY")]
+    pub schedule_every: Option<humantime::Duration>,
+}
+
+impl Scheduler {
+    pub async fn schedule(&self, f: impl Fn(time::OffsetDateTime, time::OffsetDateTime) -> ()) {
+        // extract the duration into a std::time::Duration
+        let delta = if let Some(delta) = self.schedule_every {
+            <humantime::Duration as Into<std::time::Duration>>::into(delta)
+        } else {
+            return;
+        };
+
+        let now = time::OffsetDateTime::now_utc();
+
+        // adjust the anchor time to be >= now
+        let mut anchor = if let Some(mut dt) = self.schedule_from {
+            if dt < now {
+                let x = ((now - dt) / delta).ceil() as u32;
+                dt += delta * x;
+            }
+            dt
+        } else {
+            now
+        };
+
+        // now we align the clocks as best we can
+        {
+            let sleepy: std::time::Duration = (anchor - now)
+                .try_into()
+                .expect("anchor too far in the future");
+
+            tokio::time::sleep(sleepy).await;
+        };
+
+        // Finally, we can loop over a timer
+        let mut interval = tokio::time::interval(delta);
+        loop {
+            interval.tick().await;
+            let next = anchor + delta;
+            f(anchor, next);
+            anchor = next;
+        }
+    }
+}
+
+fn parse_timestamp(timestamp: &str) -> Result<time::OffsetDateTime, time::error::Parse> {
+    time::OffsetDateTime::parse(timestamp, &time::format_description::well_known::Rfc3339)
 }


### PR DESCRIPTION
There remains some cruft around calling the solver from the server, but this defers that tech debt and does a fairly minimal rearrangement to also allow non-server calls into the solver pipeline (to facilitate the scheduler).

The scheduler itself is also super basic, but it works well enough. The goal is something simple that doesn't make any obvious mistakes; error recovery is beyond the scope of this work.