### PR TITLE
73 re enable openapi validation as test

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,12 +46,12 @@ jobs:
         run: cargo test --release --locked
       - name: Check formatting
         run: cargo fmt --check
-      # - name: Generate OpenAPI Spec
-      #   run: cargo run --bin generate-openapi --release > openapi.yaml
-      # # https://github.com/swagger-api/apidom is the modern way of validating OpenAPI specs
-      # # https://github.com/swaggerexpert/apidom-validate is a simple way of doing so via GitHub Action.
-      # # However, it builds every time, so it's not ideal;
-      # # we can either optimize this with caching or do it directly as a nodejs script.
-      # - uses: swaggerexpert/apidom-validate@v1
-      #   with:
-      #     definition-file: "openapi.yaml"
+      - name: Generate OpenAPI Spec
+        run: cargo run --bin ftdemo --release -- --secret SECRET --schema openapi.json
+      # https://github.com/swagger-api/apidom is the modern way of validating OpenAPI specs
+      # https://github.com/swaggerexpert/apidom-validate is a simple way of doing so via GitHub Action.
+      # However, it builds every time, so it's not ideal;
+      # we can either optimize this with caching or do it directly as a nodejs script.
+      - uses: swaggerexpert/apidom-validate@v1
+        with:
+          definition-file: "openapi.json"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
       - name: Generate OpenAPI Spec
-        run: cargo run --bin ftdemo --release -- --secret SECRET --schema openapi.json
+        run: cargo run --bin ftdemo --release -- schema --output openapi.json
       # https://github.com/swagger-api/apidom is the modern way of validating OpenAPI specs
       # https://github.com/swaggerexpert/apidom-validate is a simple way of doing so via GitHub Action.
       # However, it builds every time, so it's not ideal;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,7 @@ dependencies = [
  "jwt-simple",
  "schemars",
  "serde",
+ "serde_json",
  "time",
  "tokio",
  "tokio-test",

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ EXPOSE 8080
 
 # TODO: Add healthcheck?
 
-ENTRYPOINT ["/usr/local/bin/ftdemo"]
+ENTRYPOINT ["/usr/local/bin/ftdemo serve"]

--- a/fly.toml
+++ b/fly.toml
@@ -29,7 +29,7 @@ wait_timeout = "1m"
   APP_SERVER__BIND_ADDRESS = "0.0.0.0:8080"
 
 [processes]
-  app = "--secret ${DEMO_API_SECRET}"
+  app = "serve --secret ${DEMO_API_SECRET}"
 
 [[vm]]
   memory = '1gb'

--- a/ftdemo/Cargo.toml
+++ b/ftdemo/Cargo.toml
@@ -18,7 +18,8 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "string"] }
 headers = { workspace = true }
 schemars = { workspace = true, features = ["uuid1"] }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "rc"] }
+serde_json = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 uuid = { workspace = true, features = ["v4"] }
 time = { workspace = true, features = ["formatting", "parsing", "serde"] }

--- a/ftdemo/README.md
+++ b/ftdemo/README.md
@@ -8,7 +8,7 @@ It is recommended to pair this binary with a frontend client, such as [this one]
 
 The binary can be installed as simply as `cargo install ftdemo`. Once installed, running the server looks like this:
 ```bash
-APP_SECRET=SECRET ftdemo --config ./path/to/config.toml
+APP_SECRET=SECRET ftdemo serve --config ./path/to/config.toml
 ```
 
 The two key things are setting the HMAC secret for JWT authentication, and the configuration file `./path/to/config.toml`. This file looks like:

--- a/ftdemo/src/cli.rs
+++ b/ftdemo/src/cli.rs
@@ -17,6 +17,10 @@ pub struct Cli {
     /// The HMAC secret for verification of JWT claims.
     #[arg(short, long, env = "APP_SECRET")]
     pub secret: String,
+
+    /// (Optional) Write the OpenAPI schema to the provided file and exit.
+    #[arg(long)]
+    pub schema: Option<PathBuf>,
 }
 
 impl Cli {

--- a/ftdemo/src/cli.rs
+++ b/ftdemo/src/cli.rs
@@ -3,24 +3,43 @@
 //! This module defines the command-line arguments accepted by the application
 //! and provides parsing functionality using the clap crate.
 
-use clap::Parser;
-use std::path::PathBuf;
+use clap::{Parser, Subcommand};
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter, Read, Write, stdin, stdout},
+    path::PathBuf,
+    str::FromStr,
+};
 
 /// Command-line arguments for the flow trading application.
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    /// Path to configuration file.
-    #[arg(short, long, env = "APP_CONFIG")]
-    pub config: Option<PathBuf>,
+    /// The various subcommands of this program
+    #[command(subcommand)]
+    pub command: Commands,
+}
 
-    /// The HMAC secret for verification of JWT claims.
-    #[arg(short, long, env = "APP_SECRET")]
-    pub secret: String,
+/// The action to take. Currently, run a server or print the OpenAPI schema
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Run an API server with the specified config and JWT secret
+    Serve {
+        /// Path to configuration file.
+        #[arg(short, long, env = "APP_CONFIG")]
+        config: Option<PathBuf>,
 
-    /// (Optional) Write the OpenAPI schema to the provided file and exit.
-    #[arg(long)]
-    pub schema: Option<PathBuf>,
+        /// The HMAC secret for verification of JWT claims.
+        #[arg(short, long, env = "APP_SECRET")]
+        secret: String,
+    },
+
+    /// Output the OpenAPI schema for the API
+    Schema {
+        /// The location to write the OpenAPI schema
+        #[arg(short, long, default_value = "-")]
+        output: PathOrStd,
+    },
 }
 
 impl Cli {
@@ -30,5 +49,39 @@ impl Cli {
     /// structure, including validation and help text generation.
     pub fn import() -> Result<Self, clap::Error> {
         Self::try_parse()
+    }
+}
+
+#[derive(Clone)]
+pub enum PathOrStd {
+    Path(PathBuf),
+    Std,
+}
+
+impl FromStr for PathOrStd {
+    type Err = <PathBuf as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "-" {
+            Ok(Self::Std)
+        } else {
+            Ok(Self::Path(s.parse()?))
+        }
+    }
+}
+
+impl PathOrStd {
+    pub fn read(&self) -> anyhow::Result<Box<dyn Read>> {
+        match self {
+            PathOrStd::Path(path) => Ok(Box::new(BufReader::new(File::open(path)?))),
+            PathOrStd::Std => Ok(Box::new(stdin().lock())),
+        }
+    }
+
+    pub fn write(&self) -> anyhow::Result<Box<dyn Write>> {
+        match self {
+            PathOrStd::Path(path) => Ok(Box::new(BufWriter::new(File::create(path)?))),
+            PathOrStd::Std => Ok(Box::new(stdout().lock())),
+        }
     }
 }

--- a/ftdemo/src/config.rs
+++ b/ftdemo/src/config.rs
@@ -4,8 +4,9 @@
 //! with a clear precedence order. Configuration can come from default values,
 //! configuration files, and environment variables.
 
-use crate::{Cli, schedule::Scheduler};
+use crate::schedule::Scheduler;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 /// The main application configuration that composes all component configs
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -44,14 +45,14 @@ impl AppConfig {
     /// # Set scheduling interval
     /// export APP_SCHEDULE__EVERY="1h"
     /// ```
-    pub fn load(cli: &Cli) -> anyhow::Result<Self> {
+    pub fn load(file: Option<PathBuf>) -> anyhow::Result<Self> {
         let mut config = config::Config::builder();
 
         // Start with default values
         config = config.add_source(config::Config::try_from(&Self::default())?);
 
         // Layer on config file if it is specified and exists
-        if let Some(path) = &cli.config {
+        if let Some(path) = file {
             if path.exists() {
                 config = config.add_source(config::File::from(path.as_path()))
             } else {

--- a/ftdemo/src/lib.rs
+++ b/ftdemo/src/lib.rs
@@ -7,7 +7,7 @@ mod schedule;
 pub use schedule::Scheduler;
 
 mod cli;
-pub use cli::Cli;
+pub use cli::{Cli, Commands};
 
 mod config;
 pub use config::AppConfig;

--- a/ftdemo/src/main.rs
+++ b/ftdemo/src/main.rs
@@ -1,7 +1,5 @@
-use std::fs::File;
-
-use ftdemo::{AppConfig, Cli, impls::DemoApp};
-use fts_axum::{router, start_server};
+use ftdemo::{AppConfig, Cli, Commands, impls::DemoApp};
+use fts_axum::{schema, start_server};
 use fts_core::ports::BatchRepository as _;
 use fts_solver::clarabel::ClarabelSolver;
 use fts_sqlite::Db;
@@ -23,53 +21,55 @@ async fn main() -> anyhow::Result<()> {
 
     // Parse CLI args and extract the JWT key
     let cli = Cli::import()?;
-    let key = HS256Key::from_bytes(cli.secret.as_bytes());
 
-    // Create config with proper layering of CLI args
-    let AppConfig {
-        server,
-        database,
-        schedule,
-    } = AppConfig::load(&cli)?;
-
-    // Open database with config
-    let db = Db::open(&database, OffsetDateTime::now_utc().into()).await?;
-    let db2 = db.clone();
-    let app = DemoApp { db, key };
-
-    // If requested, dump the schema and exit.
-    if let Some(path) = cli.schema {
-        let schema = router(app, server).1;
-        serde_json::to_writer_pretty(File::create(path)?, &schema)?;
-        return Ok(());
-    }
-
-    // We always run the server task.
-    let server_task = tokio::spawn(async move { start_server(server, app).await });
-
-    // However, we may or may not also run a scheduled batch task
-    if schedule.every.is_some() {
-        let solver_task = tokio::spawn(async move {
-            let f = async move |now: OffsetDateTime| {
-                let batch = db2
-                    .run_batch(now.into(), ClarabelSolver::default(), ())
-                    .await;
-                match batch {
-                    Ok(Ok(())) => Ok(()),
-                    Ok(Err(e)) => Err(anyhow::Error::new(e)),
-                    Err(e) => Err(anyhow::Error::new(e)),
-                }
-            };
-            schedule.schedule(f).await
-        });
-
-        select! {
-            r = server_task => r??,
-            r = solver_task => r??,
+    match cli.command {
+        Commands::Schema { output } => {
+            let schema = schema::<DemoApp>();
+            serde_json::to_writer_pretty(output.write()?, &schema)?;
         }
-    } else {
-        // Otherwise, we just run the server task to completion
-        server_task.await??;
+        Commands::Serve { config, secret } => {
+            let key = HS256Key::from_bytes(secret.as_bytes());
+
+            // Create config with proper layering of CLI args
+            let AppConfig {
+                server,
+                database,
+                schedule,
+            } = AppConfig::load(config)?;
+
+            // Open database with config
+            let db = Db::open(&database, OffsetDateTime::now_utc().into()).await?;
+            let db2 = db.clone();
+            let app = DemoApp { db, key };
+
+            // We always run the server task.
+            let server_task = tokio::spawn(async move { start_server(server, app).await });
+
+            // However, we may or may not also run a scheduled batch task
+            if schedule.every.is_some() {
+                let solver_task = tokio::spawn(async move {
+                    let f = async move |now: OffsetDateTime| {
+                        let batch = db2
+                            .run_batch(now.into(), ClarabelSolver::default(), ())
+                            .await;
+                        match batch {
+                            Ok(Ok(())) => Ok(()),
+                            Ok(Err(e)) => Err(anyhow::Error::new(e)),
+                            Err(e) => Err(anyhow::Error::new(e)),
+                        }
+                    };
+                    schedule.schedule(f).await
+                });
+
+                select! {
+                    r = server_task => r??,
+                    r = solver_task => r??,
+                }
+            } else {
+                // Otherwise, we just run the server task to completion
+                server_task.await??;
+            }
+        }
     }
 
     Ok(())

--- a/fts-axum/src/lib.rs
+++ b/fts-axum/src/lib.rs
@@ -42,25 +42,34 @@ async fn health_check() -> Json<HealthResponse> {
     })
 }
 
-/// Construct a full API router with the given state and config
-pub fn router<T: ApiApplication>(state: T, config: AxumConfig) -> (axum::Router, Arc<OpenApi>) {
+/// Extract the OpenAPI documentation for the server
+pub fn schema<T: ApiApplication>() -> OpenApi {
     let mut api = OpenApi::default();
-    let router = ApiRouter::new()
+    let _ = ApiRouter::new()
+        .api_route("/health", get(health_check))
+        .nest("/product", product_routes::router::<T>())
+        .nest("/demand", demand_routes::router::<T>())
+        .nest("/portfolio", portfolio_routes::router::<T>())
+        .nest("/batch", batch_routes::router::<T>())
+        .nest_api_service("/docs", docs_routes())
+        .finish_api_with(&mut api, api_docs);
+    api
+}
+
+/// Construct a full API router with the given state and config
+pub fn router<T: ApiApplication>(state: T, config: AxumConfig) -> axum::Router {
+    let mut api = OpenApi::default();
+    ApiRouter::new()
         .api_route("/health", get(health_check))
         .nest("/product", product_routes::router())
         .nest("/demand", demand_routes::router())
         .nest("/portfolio", portfolio_routes::router())
         .nest("/batch", batch_routes::router())
         .nest_api_service("/docs", docs_routes())
-        .finish_api_with(&mut api, api_docs);
-    let schema = Arc::new(api);
-    (
-        router
-            .layer(Extension(schema.clone())) // Arc is very important here or you will face massive memory and performance issues
-            .layer(Extension(Arc::new(config)))
-            .with_state(state),
-        schema,
-    )
+        .finish_api_with(&mut api, api_docs)
+        .layer(Extension(Arc::new(api))) // Arc is very important here or you will face massive memory and performance issues
+        .layer(Extension(Arc::new(config)))
+        .with_state(state)
 }
 
 /// Starts the HTTP server with the provided configuration
@@ -78,7 +87,7 @@ pub async fn start_server<T: ApiApplication>(
     );
 
     // Here, we could apply additional config like timeouts, CORS, etc.
-    let service = router(app, config).0;
+    let service = router(app, config);
     axum::serve(listener, service).await
 }
 

--- a/fts-axum/tests/api.rs
+++ b/fts-axum/tests/api.rs
@@ -23,7 +23,7 @@ async fn test_api(#[files("tests/api/**/*.hurl")] test: PathBuf) {
         TestApp(db)
     };
 
-    let router = router(app, AxumConfig::default()).0;
+    let router = router(app, AxumConfig::default());
 
     // Run the test server on a local TCP port
     let server = TestServer::new_with_config(

--- a/fts-axum/tests/api.rs
+++ b/fts-axum/tests/api.rs
@@ -23,7 +23,7 @@ async fn test_api(#[files("tests/api/**/*.hurl")] test: PathBuf) {
         TestApp(db)
     };
 
-    let router = router(app, AxumConfig::default());
+    let router = router(app, AxumConfig::default()).0;
 
     // Run the test server on a local TCP port
     let server = TestServer::new_with_config(


### PR DESCRIPTION
First steps to reenabling a basic OpenAPI schema check.

The current approach is to augment `ftdemo` to also take an optional schema location to write to. If provided, simply write the file and exist. TODO: this is a bit hacky -- really ftdemo can generate the schema, or it can run the server. Since this was quick and dirty, one still needs to pass --secret to the binary even if all you're doing is generated the schema. :-(